### PR TITLE
Preliminary support for USB Armory (i.MX53) devices

### DIFF
--- a/Freescale/iMX53/USBarmory_MkI/devicetree.dtsi
+++ b/Freescale/iMX53/USBarmory_MkI/devicetree.dtsi
@@ -1,0 +1,21 @@
+/*
+ * USB armory MkI devicetree
+ *
+ * Based on the Linux one.
+ */
+
+#include "Skeleton.dtsi"
+#include "iMX53.dtsi"
+
+/ {
+    compatible = "inversepath,imx53-usbarmory", "fsl,imx53", "AppleARM";
+    model = "Inverse Path USB armory MkI";
+
+    /*
+     * SDRAM allocation.
+     */
+    memory {
+        device_type = "memory";
+        reg = <0x70000000 0x20000000>; /* 512 MB */
+    };
+};

--- a/Include/iMX53.dtsi
+++ b/Include/iMX53.dtsi
@@ -1,0 +1,51 @@
+/*
+ * i.MX53 Device Tree.
+ *
+ * Based on the Linux one.
+ */
+
+/ {
+	compatible = "fsl,imx53", "AppleARM";
+	
+    /*
+     * CPU nodes
+     */
+    cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a8";
+			reg = <0x0>;
+		};
+	};
+	
+	tzic: tz-interrupt-controller@0fffc000 {
+		compatible = "fsl,imx53-tzic", "fsl,tzic";
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		reg = <0x0fffc000 0x4000>;
+	};
+	
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "simple-bus";
+		interrupt-parent = <&tzic>;
+		ranges;
+
+		aipstz@50000000 { /* AIPSTZ-1 */
+			compatible = "fsl,aips-bus", "simple-bus";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x50000000 0x10000000>;
+			ranges;
+
+			uart1: serial@53fbc000 {
+				compatible = "fsl,imx53-uart", "fsl,imx21-uart";
+				reg = <0x53fbc000 0x4000>;
+				AAPL,interrupts = <31>;
+			};
+		};
+	};
+};

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CPPFLAGS	= -E -P -nostdinc -IInclude -undef -x assembler-with-cpp
 CPP		= clang
 DTC		= dtc
 DEVICETREES	= RealView.devicetree Nokia_RX51.devicetree \
-	TI_BeagleXM.devicetree
+	TI_BeagleXM.devicetree USBarmory_MkI.devicetree
 
 all: $(DEVICETREES)
 
@@ -21,6 +21,10 @@ TI_BeagleXM.devicetree: TexasInstruments/OMAP3/BeagleBoardXM/devicetree.dtsi
 	$(DTC) -O dtb -o $@ $@.p
 	rm -f $@.p
 
+USBarmory_MkI.devicetree: Freescale/iMX53/USBarmory_MkI/devicetree.dtsi
+	$(CPP) $(CPPFLAGS) $< -o $@.p
+	$(DTC) -O dtb -o $@ $@.p
+	rm -f $@.p
+
 clean:
 	rm -f $(DEVICETREES)
-


### PR DESCRIPTION
Simple device tree to make GenericBooter happy. Most of the hardware isn't present here yet, but we're not at a point where that really matters anyway.
